### PR TITLE
chore: update README copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ If the exercise isn't ready in 20 seconds, please check the [Actions](../../acti
 
 ---
 
-&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+&copy; 2026 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)


### PR DESCRIPTION
There have been 3 commits this year, so why not?