### PR TITLE
fix: incorrect description about default commit messages and pr titles

### DIFF
--- a/.github/steps/2-commit-a-file.md
+++ b/.github/steps/2-commit-a-file.md
@@ -31,15 +31,17 @@ The following steps will guide you through the process of committing a change on
 
 5. Click **Commit changes...** in the upper right corner above the contents box. A dialog will appear.
 
-6. GitHub offers a simple default message, but let's change it slightly for practice. Enter `Add PROFILE.md` in the **Commit message** field.
-   
+6. GitHub may suggest a commit message, but let's set one ourselves for practice. Enter `Add PROFILE.md` in the **Commit message** field.
+
    - A **commit message** and optional **extended description** help provide clarity for your changes. This is particularly useful when your commit involves several files.
+
+   <br>
 
    <img width="400" alt="screenshot of adding a new file with a commit message" src="../images/commit-message-dialog.png">
 
-6. In this lesson, we'll ignore the other fields for now and click **Commit changes**.
+7. In this lesson, we'll ignore the other fields for now and click **Commit changes**.
 
-7. Now that you've changed a file, Mona should already be busy checking your work. Give her a moment and keep watch in the comments. You will see her respond with progress info and the next lesson.
+8. Now that you've changed a file, Mona should already be busy checking your work. Give her a moment and keep watch in the comments. You will see her respond with progress info and the next lesson.
 
 
 <details>

--- a/.github/steps/2-commit-a-file.md
+++ b/.github/steps/2-commit-a-file.md
@@ -31,7 +31,7 @@ The following steps will guide you through the process of committing a change on
 
 5. Click **Commit changes...** in the upper right corner above the contents box. A dialog will appear.
 
-6. GitHub may suggest a commit message, but let's set one ourselves for practice. Enter `Add PROFILE.md` in the **Commit message** field.
+6. GitHub will suggest a commit message, but let's set one ourselves for practice. Enter `Add PROFILE.md` in the **Commit message** field.
 
    - A **commit message** and optional **extended description** help provide clarity for your changes. This is particularly useful when your commit involves several files.
 

--- a/.github/steps/2-commit-a-file.md
+++ b/.github/steps/2-commit-a-file.md
@@ -35,8 +35,6 @@ The following steps will guide you through the process of committing a change on
 
    - A **commit message** and optional **extended description** help provide clarity for your changes. This is particularly useful when your commit involves several files.
 
-   <br>
-
    <img width="400" alt="screenshot of adding a new file with a commit message" src="../images/commit-message-dialog.png">
 
 7. In this lesson, we'll ignore the other fields for now and click **Commit changes**.

--- a/.github/steps/3-open-a-pull-request.md
+++ b/.github/steps/3-open-a-pull-request.md
@@ -25,7 +25,7 @@ To create a pull request automatically, click **Compare & pull request** button,
 
 4. Click **Create pull request**.
 
-5. Enter a title for your pull request. By default, the title will automatically be the name of your branch. For this exercise, let's edit the field to say `Add my first file`.
+5. Enter a title for your pull request. GitHub may use your commit message as the default title. For this exercise, let's edit the field to say `Add my first file`.
 
 6. The next field helps you provide a **description** of the changes you made. Please enter a short description of what you’ve accomplished so far. As a reminder, you have: created a new branch, created a file, and made a commit.
 

--- a/.github/steps/3-open-a-pull-request.md
+++ b/.github/steps/3-open-a-pull-request.md
@@ -25,7 +25,7 @@ To create a pull request automatically, click **Compare & pull request** button,
 
 4. Click **Create pull request**.
 
-5. Enter a title for your pull request. GitHub may use your commit message as the default title. For this exercise, let's edit the field to say `Add my first file`.
+5. Enter a title for your pull request. By default, the title will be your commit message. For this exercise, let's edit the field to say `Add my first file`.
 
 6. The next field helps you provide a **description** of the changes you made. Please enter a short description of what you’ve accomplished so far. As a reminder, you have: created a new branch, created a file, and made a commit.
 


### PR DESCRIPTION
### Summary
Updates the tutorial instructions to reflect current GitHub behavior for generated commit messages and pull request titles.

### Changes
- Clarifies that GitHub may suggest a commit message, and instructs learners to set `Add PROFILE.md` themselves for practice.
- Updates the pull request title guidance to note that GitHub may use the commit message as the default title.
- Fixes the Step 2 numbering after the commit message instruction.
- Cleans up spacing before the nested commit message explanation.

Closes: #2202

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).
