### PR TITLE
fix: update broken discussion board link

### DIFF
--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -19,7 +19,7 @@ If you'd like to make a profile README, use the quickstart instructions below or
 2. Create a file named `README.md` in its root. The "root" means not inside any folder in your repository.
 3. Edit the contents of the `README.md` file.
 4. If you created a new branch for your file, open and merge a pull request on your branch.
-5. Lastly, we'd love to hear what you thought of this exercise [in our discussion board](https://github.com/orgs/skills/discussions/categories/introduction-to-github).
+5. Lastly, we'd love to hear what you thought of this exercise [in our discussion board](https://github.com/orgs/community/discussions/categories/github-learn).
 
 Check out these resources to learn more or get involved:
 


### PR DESCRIPTION
### Summary
Fixes a 404 broken link in the "What's next?" section of the course instructions.


### Changes
Updates the dead `/orgs/skills/discussions` URL to the active GitHub Learn community category (`https://github.com/orgs/community/discussions/categories/github-learn`).

Closes:


### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).